### PR TITLE
Add pybluez to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ https://extensions.gnome.org/extension/3991/bluetooth-battery/
 
 ## Requirements
 
-* bluez (on ubuntu: sudo apt install bluez)
-* python3 (on ubuntu: sudo apt install python3-dev)
-* libbluetooth (on ubuntu: sudo apt install libbluetooth-dev)
+* bluez
+* python3 (on ubuntu: python3-dev)
+* libbluetooth (on ubuntu: libbluetooth-dev)
+* pybluez
 
 ```
-sudo apt install bluez libbluetooth-dev python3-dev
+sudo apt install bluez libbluetooth-dev python3-dev pybluez
 ```
 
 ## Manual Installation


### PR DESCRIPTION
- `pybluez` is required by [`bluetooth_battery.py`](https://github.com/TheWeirdDev/Bluetooth_Headset_Battery_Level/blob/bbfa282e4e231f3b74eb7d59a151bdb37bdb4c4d/bluetooth_battery.py#L12)
- remove `sudo apt install ...` redundancies.