### PR TITLE
Fix upower script to work for 100% charged devices, and switch from using sed to using awk.

### DIFF
--- a/scripts/upower_battery.sh
+++ b/scripts/upower_battery.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# sed explaination: https://stackoverflow.com/questions/13534306/how-can-i-set-the-grep-after-context-to-be-until-the-next-blank-line
+# awk explaination: https://stackoverflow.com/questions/13534306/how-can-i-set-the-grep-after-context-to-be-until-the-next-blank-line
 # grep explaination: https://stackoverflow.com/questions/1546711/can-grep-show-only-words-that-match-search-pattern
-percent=$(upower --dump | sed -n "/$1/,/^$/p" | grep -oE '[0-9]{1,2}%')
+percent=$(upower --dump | awk "/$1/" RS= | grep -oE '[0-9]{1,3}%')
 connected=$(bluetoothctl info $1 | grep "Connected" | cut -d ' ' -f2)
 
 if [[ $connected == "yes" ]]; then


### PR DESCRIPTION
I noticed that my script using Upower didn't work when the device was charged to 100%, so this PR fixes that, and it changes the script from using sed to using awk as sed gave an error. 