### PR TITLE
Fixed case mismatch in UPower script

### DIFF
--- a/scripts/upower_battery.sh
+++ b/scripts/upower_battery.sh
@@ -2,7 +2,7 @@
 
 # awk explaination: https://stackoverflow.com/questions/13534306/how-can-i-set-the-grep-after-context-to-be-until-the-next-blank-line
 # grep explaination: https://stackoverflow.com/questions/1546711/can-grep-show-only-words-that-match-search-pattern
-percent=$(upower --dump | awk "/$1/" RS= | grep -oE '[0-9]{1,3}%')
+percent=$(upower --dump | tr '[:lower:]' '[:upper:]' | awk "/$1/" RS= | grep -oE '[0-9]{1,3}%')
 connected=$(bluetoothctl info $1 | grep "Connected" | cut -d ' ' -f2)
 
 if [[ $connected == "yes" ]]; then


### PR DESCRIPTION
I am not very experienced in UPower, however I have two devices whose battery level is reported through UPower but not through `bluetoothctl`. 

However, in my installation (Fedora 35), and for the three BT devices I have `upower --dump` returns MAC addresses in lower case, whereas the extension always holds the MAC addresses in upper case. I consequently added a `tr '[:lower:]' '[:upper:]'` after getting `upower` information before parsing devices with `awk`. This resolved the ? battery level in my case.

https://github.com/MichalW/gnome-bluetooth-battery-indicator/issues/31#issuecomment-1059751899 for pointing the issue.