### PR TITLE
Fix 'SyntaxError: fields are currently not supported' in gnome-shell version 3.36.9.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -136,11 +136,13 @@ class Extension {
         ];
     }
 
-    _setPercentFromScript = (index) => (result) => {
-        const resultArray = result.split(' ');
-        const percent = resultArray[resultArray.length - 1];
-        this._indicator.setPercentLabel(percent, index);
-    };
+    _setPercentFromScript(index) {
+        return (result) => {
+            const resultArray = result.split(' ');
+            const percent = resultArray[resultArray.length - 1];
+            this._indicator.setPercentLabel(percent, index);
+        };
+    }
 
     _getBatteryLevel(btMacAddress, port, index) {
         const pyLocation = Me.dir.get_child(PYTHON_SCRIPT_PATH).get_path();


### PR DESCRIPTION
Reportedly, in issue #35, it also doesn't work for other versions.

The fix was to redefine the function _setPercentFromScript to be a function that returns a function. My guess is that previously, that function was defined as a member/field (don't know the correct terminology in JS) and that is, for some odd reason, not supported in some gnome-shell versions.