### PR TITLE
Add Brazilian Portuguese translation

### DIFF
--- a/po/pt-br.po
+++ b/po/pt-br.po
@@ -1,0 +1,110 @@
+# Brazilian Portuguese translation.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Wagner Skellington <wagner@wasp-inc.com.br>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-17 12:24+0100\n"
+"PO-Revision-Date: 2022-04-08 05:38-0300\n"
+"Last-Translator: Wagner Skellington <wagner@wasp-inc.com.br>\n"
+"Language-Team: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: extension.js:55
+msgid "Refresh"
+msgstr "Atualizar"
+
+#: extension.js:63
+msgid "Force refresh bluetooth"
+msgstr "Forçar atualização do Bluetooth"
+
+#: indicator.js:11
+msgid "Bluetooth battery Indicator"
+msgstr "Indicador de bateria Bluetooth"
+
+#: indicator.js:36
+msgid "Settings"
+msgstr "Configurações"
+
+#: settingsWidget.js:78
+msgid "Indicator Settings"
+msgstr "Configurações do Indicador"
+
+#: settingsWidget.js:93
+msgid "Refresh interval (minutes)"
+msgstr "Intervalo de atualização (minutos)"
+
+#: settingsWidget.js:101
+msgid "Hide indicator if there are no devices"
+msgstr "Ocultar indicador se não houver dispositivos"
+
+#: settingsWidget.js:154
+msgid "Name"
+msgstr "Nome"
+
+#: settingsWidget.js:155
+msgid "Status"
+msgstr "Estado"
+
+#: settingsWidget.js:156
+msgid "Icon"
+msgstr "Ícone"
+
+#: settingsWidget.js:157
+msgid "Port"
+msgstr "Porta"
+
+#: settingsWidget.js:158
+msgid "% Source"
+msgstr "% Fonte"
+
+#: settingsWidget.js:178
+msgid "Devices"
+msgstr "Dispositivos"
+
+#: settingsWidget.js:226 settingsWidget.js:260
+msgid "Default"
+msgstr "Padrão"
+
+#: settingsWidget.js:227
+msgid "Headphones"
+msgstr "Fones de ouvido"
+
+#: settingsWidget.js:228
+msgid "Mouse"
+msgstr "Mouse"
+
+#: settingsWidget.js:229
+msgid "Keyboard"
+msgstr "Teclado"
+
+#: settingsWidget.js:230
+msgid "Headset"
+msgstr "Fones com microfone"
+
+#: settingsWidget.js:231
+msgid "Game Controller"
+msgstr "Controle para Jogos"
+
+#: settingsWidget.js:232
+msgid "Battery"
+msgstr "Bateria"
+
+#: settingsWidget.js:307
+msgid "Python script"
+msgstr "Script em Python"
+
+#: settingsWidget.js:308
+msgid "Bluetoothctl"
+msgstr "Bluetoothctl"
+
+#: settingsWidget.js:309
+msgid "UPower"
+msgstr "UPower"


### PR DESCRIPTION
Done using [bluetooth-battery-indicator.pot](https://github.com/MichalW/gnome-bluetooth-battery-indicator/blob/aa9665005b186f8bd4a9b0572a151d95e09122b8/po/bluetooth-battery-indicator.pot) as reference.