### PR TITLE
Add shell version 43 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth_battery_indicator",
   "gettext-domain": "bluetooth_battery_indicator",
   "url": "https://github.com/MichalW/gnome-bluetooth-battery-indicator",
-  "shell-version": ["42"]
+  "shell-version": ["42", "43"]
 }


### PR DESCRIPTION
The extension works without any changes required in GNOME Shell 43.

Closes #51