### PR TITLE
Remove deprecated object.actor

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -113,7 +113,7 @@ class Extension {
         this._settings.setDevices(devices);
 
         if (settingsHideIndicator) {
-            Main.panel.statusArea[this._uuid].actor.visible = !!devicesToShow.length;
+            Main.panel.statusArea[this._uuid].visible = !!devicesToShow.length;
         }
     }
 


### PR DESCRIPTION
Fixes:

```
Usage of object.actor is deprecated for Indicator
get@resource:///org/gnome/shell/ui/environment.js:387:29
 _refresh@/home/prahal/.local/share/gnome-shell/extensions/bluetooth-battery@michalw.github.com/extension.js:116:13
 _enableSignals/<@/home/prahal/.local/share/gnome-shell/extensions/bluetooth-battery@michalw.github.com/extension.js:43:18
 _emit@resource:///org/gnome/gjs/modules/core/_signals.js:114:47
 enable/<@/home/prahal/.local/share/gnome-shell/extensions/bluetooth-battery@michalw.github.com/bluetooth.js:16:70
```
this happens when "hide indicator if no device found" is set.