### PR TITLE
Add shell version 44 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth_battery_indicator",
   "gettext-domain": "bluetooth_battery_indicator",
   "url": "https://github.com/MichalW/gnome-bluetooth-battery-indicator",
-  "shell-version": ["42", "43"]
+  "shell-version": ["42", "43", "44"]
 }


### PR DESCRIPTION
Working normally on version 44:

![Screenshot from 2023-04-19 18-50-10](https://user-images.githubusercontent.com/17055027/233208305-4a719c47-580b-4df8-ae44-ff9af9ea163e.png)
