### PR TITLE
Prefer device alias over device name

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -25,6 +25,7 @@ var BluetoothController = class {
             if(device == null) continue
             devices.push({
                 name:        device.name,
+                alias:       device.alias,
                 isConnected: device.connected,
                 isPaired:    device.paired,
                 mac:         device.address,

--- a/settingsWidget.js
+++ b/settingsWidget.js
@@ -174,7 +174,9 @@ var SettingsWidget = GObject.registerClass(
                 ...getMarginAll(BOX_PADDING),
             });
 
-            addToBox(hBox, this._getLabel(device.name));
+            const isEmptyAlias = !device.alias || device.alias.trim().length === 0;
+
+            addToBox(hBox, this._getLabel(isEmptyAlias ? device.name : device.alias));
             addToBox(hBox, this._getDeviceSwitchButton(device));
             addToBox(hBox, this._getDeviceIconComboBox(device));
             addToBox(hBox, this._getPortComboBox(device));


### PR DESCRIPTION
There might be multiple bluetooth devices of the same product. For example - familiy members buy the same headphone model. Those devices will have the same name. Choosing from a list of devices with the same name is hard.
You can not change the name of a device. BUT you can set an alias for each device (e.g. terminal and bluetoothctl).

- GnomeBluetooth.Client already exposes the alias property.
- This commit prefers the device alias (if not empty) over the device name.
- So it is shown in the extensions settings ui.
- Gnome uses the same behaviour in bluetooth settings.
- Nothing changes if no alias is given.

![old_new_settings_small](https://github.com/MichalW/gnome-bluetooth-battery-indicator/assets/1742347/7ea12994-a5dd-4109-bc33-5cefae793e6e)


