### PR TITLE
fix(translations): set charset to valid value

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: Gnome.CZE\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: extension.js:55


### PR DESCRIPTION
Currently the build fails with a rather cryptic error:

```sh
$ make
glib-compile-schemas ./schemas
cp -R Bluetooth_Headset_Battery_Level .Bluetooth_Headset_Battery_Level
rm -f Bluetooth_Headset_Battery_Level/.git
Bluetooth_Headset_Battery_Level/.gitignore
Bluetooth_Headset_Battery_Level/Dockerfile
Bluetooth_Headset_Battery_Level/__init__.py
gnome-extensions pack -f --extra-source=Bluetooth_Headset_Battery_Level
--extra-source=scripts/ --extra-source=bluetooth.js
--extra-source=constants.js     --extra-source=indicator.js
--extra-source=LICENSE --extra-source=README.md --e
xtra-source=settings.js --extra-source=settingsWidget.js
--extra-source=utils.js . --out-dir=./
Child process exited with code 1
make: *** [Makefile:10: build] Error 2
```

Unfortunatly `gnome-extensions pack` discards the `STDERR` which is from the `msgfmt` command:

```sh
/usr/bin/msgfmt -o /tmp/bluetooth_battery_indicator.mo po/cs.po
po/cs.po:
warning: Charset "CHARSET" is not a portable encoding name.
    Message conversion to user's charset might not work.
/usr/bin/msgfmt: present charset "CHARSET" is not a portable encoding name
```