### PR TITLE
Gnome 45 support

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -1,7 +1,8 @@
-const GnomeBluetooth = imports.gi.GnomeBluetooth;
-const Signals = imports.misc.signals;
+import GnomeBluetooth from 'gi://GnomeBluetooth';
 
-var BluetoothController = class extends Signals.EventEmitter {
+import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
+
+export class BluetoothController extends Signals.EventEmitter {
     constructor() {
         super();
 

--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,5 @@
-var PYTHON_SCRIPT_PATH = 'Bluetooth_Headset_Battery_Level/bluetooth_battery.py';
-var BTCTL_SCRIPT_PATH = 'scripts/bluetoothctl_battery.sh'
-var UPOWER_SCRIPT_PATH = 'scripts/upower_battery.sh'
-var TOGGLE_SCRIPT_PATH = 'scripts/bluetoothctl_toggle.sh';
+export const UUID = "bluetooth-battery@michalw.github.com";
+export const PYTHON_SCRIPT_PATH = 'Bluetooth_Headset_Battery_Level/bluetooth_battery.py';
+export const BTCTL_SCRIPT_PATH = 'scripts/bluetoothctl_battery.sh'
+export const UPOWER_SCRIPT_PATH = 'scripts/upower_battery.sh'
+export const TOGGLE_SCRIPT_PATH = 'scripts/bluetoothctl_toggle.sh';

--- a/extension.js
+++ b/extension.js
@@ -27,21 +27,22 @@ class Extension {
         this._indicator = new IndicatorController();
         Main.panel.addToStatusArea(this._uuid, this._indicator);
 
-        this._controller.enable();
         this._getRefreshButton();
         this._getForceRefreshButton();
 
         this._loop = MainLoop.idle_add(this._runLoop.bind(this));
 
         GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10, () => {
-            this._enableSignals();
+            this._connectSignals();
         });
     }
 
-    _enableSignals() {
-        this._connectSignal(this._controller, 'device-changed', () => {
-            this._refresh();
-        });
+    _connectSignals() {
+        this._controller.connectObject('device-changed', () => this._refresh(), this);
+    }
+
+    _disconnectSignals() {
+        this._controller.disconnectObject(this);
     }
 
     _runLoop() {
@@ -198,8 +199,6 @@ class Extension {
         this._indicator = null;
     }
 }
-
-Utils.addSignalsHelperMethods(Extension.prototype);
 
 function init(meta) {
     return new Extension(meta.uuid);

--- a/indicator.js
+++ b/indicator.js
@@ -1,11 +1,14 @@
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-const Util = imports.misc.util;
-const { GObject, St, Clutter } = imports.gi;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
 
-const UUID = "bluetooth-battery@michalw.github.com";
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
-var IndicatorController = GObject.registerClass(
+import * as Constants from './constants.js';
+
+export const IndicatorController = GObject.registerClass(
     class Indicator extends PanelMenu.Button {
         _init() {
             super._init(0.0, _('Bluetooth battery Indicator'));
@@ -35,7 +38,7 @@ var IndicatorController = GObject.registerClass(
         _addSettingsButton() {
             const settings = new PopupMenu.PopupMenuItem(_('Settings'));
             settings.connect('activate', () => {
-                Util.spawn(['gnome-extensions', 'prefs', UUID]);
+                Util.spawn(['gnome-extensions', 'prefs', Constants.UUID]);
             });
             this._addMenuItem(settings);
         }

--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth_battery_indicator",
   "gettext-domain": "bluetooth_battery_indicator",
   "url": "https://github.com/MichalW/gnome-bluetooth-battery-indicator",
-  "shell-version": ["42", "43", "44"]
+  "shell-version": ["45"]
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,30 +1,9 @@
-'use strict';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
-const GObject = imports.gi.GObject;
-const Config = imports.misc.config;
+import SettingsWidget from './settingsWidget.js';
 
-// It's common practice to keep GNOME API and JS imports in separate blocks
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SettingsWidget } = Me.imports.settingsWidget;
-
-function init() {
-    log(`initializing ${Me.metadata.name} Preferences`);
-
-    ExtensionUtils.initTranslations();
-}
-
-function buildPrefsWidget() {
-    const prefsWidget = new SettingsWidget();
-    prefsWidget.show();
-
-    // At the time buildPrefsWidget() is called, the window is not yet prepared
-    // so if you want to access the headerbar you need to use a small trick
-    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 0, () => {
-        const window = prefsWidget.get_root();
-    });
-
-    return prefsWidget;
+export default class BluetoothBatteryIndicatorExtensionPreferences extends ExtensionPreferences {
+    getPreferencesWidget() {
+        return new SettingsWidget();
+    }
 }

--- a/settings.js
+++ b/settings.js
@@ -1,14 +1,10 @@
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
 const INTERVAL_KEY = 'interval';
 const HIDE_INDICATOR_KEY = 'hide-indicator';
-const USE_TOGGLE_BLUETOOTH = 'use-toggle-bluetooth';
 const DEVICES_KEY = 'devices';
 
-var SettingsController = class SettingsController {
-    constructor() {
-        this._settings = ExtensionUtils.getSettings(Me.metadata['settings-schema']);
+export class SettingsController {
+    constructor(settings) {
+        this._settings = settings;
     }
 
     getInterval() {

--- a/settingsWidget.js
+++ b/settingsWidget.js
@@ -1,16 +1,13 @@
-const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
 
-const Config = imports.misc.config;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SettingsController } = Me.imports.settings;
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = ExtensionUtils.gettext;
+import * as Constants from './constants.js';
+import {SettingsController} from './settings.js';
 
 const BOX_PADDING = 8;
 const MARGIN_BOTTOM = 8;
-const WIDGET_PADDING = 16;
 
 const getMarginAll = (value) => ({
     margin_start: value,
@@ -23,18 +20,18 @@ const addToBox = (box, element) => {
     box.append(element);
 }
 
-var SettingsWidget = GObject.registerClass(
-    class MyPrefsWidget extends Gtk.Box {
+export default GObject.registerClass(
+    class SettingsWidget extends Gtk.Box {
         _init(params) {
             super._init(params);
-            this._settings = new SettingsController();
+            this._settings = new SettingsController(
+                ExtensionPreferences.lookupByUUID(Constants.UUID).getSettings()
+            );
 
             this.set_orientation(Gtk.Orientation.VERTICAL);
 
             addToBox(this, this._getIndicatorSettingsFrame());
             addToBox(this, this._getDevicesFrame());
-
-            //this.connect('destroy', Gtk.main_quit);
         }
 
         _getIndicatorSettingsFrame() {

--- a/utils.js
+++ b/utils.js
@@ -14,27 +14,6 @@ function spawn(command, callback) {
         GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, callback);
 }
 
-function addSignalsHelperMethods(prototype) {
-    prototype._connectSignal = function (subject, signal_name, method) {
-        if (!this._signals) this._signals = [];
-
-        let signal_id = subject.connect(signal_name, method);
-        this._signals.push({
-            subject: subject,
-            signal_id: signal_id
-        });
-    }
-
-    prototype._disconnectSignals = function () {
-        if (!this._signals) return;
-
-        this._signals.forEach((signal) => {
-            signal.subject.disconnect(signal.signal_id);
-        });
-        this._signals = [];
-    };
-}
-
 function getPythonExec() {
 	//return ['python', 'python3', 'python2'].find(cmd => GLib.find_program_in_path(cmd));
 	return ['python3'].find(cmd => GLib.find_program_in_path(cmd)); //Hotfix for no percentage shown

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
-function spawn(command, callback) {
+export function spawn(command, callback) {
     let [status, pid] = GLib.spawn_async(
         null,
         ['/usr/bin/env', 'bash', '-c', command],
@@ -14,12 +14,12 @@ function spawn(command, callback) {
         GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, callback);
 }
 
-function getPythonExec() {
+export function getPythonExec() {
 	//return ['python', 'python3', 'python2'].find(cmd => GLib.find_program_in_path(cmd));
 	return ['python3'].find(cmd => GLib.find_program_in_path(cmd)); //Hotfix for no percentage shown
 }
 
-function runPythonScript(argv, onSuccess) {
+export function runPythonScript(argv, onSuccess) {
     try {
         const proc = Gio.Subprocess.new(argv, Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
 


### PR DESCRIPTION
Resolves #69.

### [Signals](https://gjs.guide/extensions/upgrading/gnome-shell-43.html#signals)

`Signals.addSignalMethods()` doesn't work anymore in Gnome 45. The replacement `Signals.EventEmitter` was added in Gnome 43. Using `connectObject()` and `disconnectObject()` is easier than manually keeping track of the signal ids.

### [Mainloop](https://gitlab.gnome.org/GNOME/gjs/-/blob/gnome-45/doc/Mainloop.md)

The `Mainloop` module hasn't been recommended for a while, and can't be used anymore in Gnome 45.

### [Imports](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#esm)

Gnome 45 moved to ESM imports.

### [ExtensionUtils](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#extension-js)

`ExtensionUtils` was replaced by `Extension` and `ExtensionPreferences` classes.

### [Compatibility](https://gitlab.gnome.org/GNOME/gjs/-/blob/gnome-45/doc/Mainloop.md)

These changes make the code incompatible with earlier Gnome version.