### PR TITLE
Add support for Gnome Shell 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth_battery_indicator",
   "gettext-domain": "bluetooth_battery_indicator",
   "url": "https://github.com/MichalW/gnome-bluetooth-battery-indicator",
-  "shell-version": [ "45", "46", "47" ]
+  "shell-version": [ "45", "46", "47", "48" ]
 }


### PR DESCRIPTION
The extensions works just fine using latest debian 13 trixie