### PR TITLE
Update metadata.json for GNOME 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth_battery_indicator",
   "gettext-domain": "bluetooth_battery_indicator",
   "url": "https://github.com/MichalW/gnome-bluetooth-battery-indicator",
-  "shell-version": [ "45", "46", "47", "48" ]
+  "shell-version": [ "45", "46", "47", "48", "49" ]
 }


### PR DESCRIPTION
The extension seems to work fine once `metadata.json` has been edited on my local machine running Fedora 43.

Closes #92 