### PR TITLE
Update metadata.json for GNOME 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "settings-schema": "org.gnome.shell.extensions.bluetooth_battery_indicator",
   "gettext-domain": "bluetooth_battery_indicator",
   "url": "https://github.com/MichalW/gnome-bluetooth-battery-indicator",
-  "shell-version": [ "45", "46", "47", "48", "49" ]
+  "shell-version": [ "45", "46", "47", "48", "49", "50" ]
 }


### PR DESCRIPTION
Just like for GNOME 49, declaring support for GNOME 50 is enough for it to work. Tested on Fedora 44, I haven't noticed any breakage.